### PR TITLE
Current models

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ Run `llm models` to list the models, and `llm models --options` to include a lis
 Run prompts like this:
 
 ```bash
-llm -m llama-3.1-sonar-small-128k-online 'Fun facts about pelicans'
-llm -m llama-3.1-sonar-large-128k-online 'Fun facts about walruses'
-llm -m llama-3.1-sonar-small-128k-chat 'Fun facts about wolves'
-llm -m llama-3.1-sonar-large-128k-chat 'Fun facts about foxes'
+llm -m sonar-small 'Fun facts about pelicans'
+llm -m sonar-large 'Fun facts about walruses'
+llm -m sonar-huge 'Fun facts about whales'
+llm -m sonar-small-chat 'Fun facts about wolves'
+llm -m sonar-large-chat 'Fun facts about foxes'
 llm -m llama-3.1-8b-instruct 'Fun facts about lemurs'
 llm -m llama-3.1-70b-instruct 'Fun facts about coyotes'
 ```

--- a/llm_perplexity.py
+++ b/llm_perplexity.py
@@ -7,21 +7,13 @@ from typing import Optional, List
 @llm.hookimpl
 def register_models(register):
     # https://docs.perplexity.ai/docs/model-cards
-    register(Perplexity("llama-3.1-sonar-small-128k-online"))
-    register(Perplexity("llama-3.1-sonar-large-128k-online"))
-    register(Perplexity("llama-3.1-sonar-small-128k-chat"))
-    register(Perplexity("llama-3.1-sonar-large-128k-chat"))
+    register(Perplexity("llama-3.1-sonar-small-128k-online"), aliases=("sonar-small",))
+    register(Perplexity("llama-3.1-sonar-large-128k-online"), aliases=("sonar-large",))
+    register(Perplexity("llama-3.1-sonar-huge-128k-online"), aliases=("sonar-huge",))
+    register(Perplexity("llama-3.1-sonar-small-128k-chat"), aliases=("sonar-small-chat",))
+    register(Perplexity("llama-3.1-sonar-large-128k-chat"), aliases=("sonar-large-chat",))
     register(Perplexity("llama-3.1-70b-instruct"))
     register(Perplexity("llama-3.1-8b-instruct"))
-    
-    # The following models will be deprecated on August 12 2024
-    register(Perplexity("llama-3-sonar-small-32k-chat"))
-    register(Perplexity("llama-3-sonar-small-32k-online"))
-    register(Perplexity("llama-3-sonar-large-32k-chat"))
-    register(Perplexity("llama-3-sonar-large-32k-online"))
-    register(Perplexity("llama-3-8b-instruct"))
-    register(Perplexity("llama-3-70b-instruct"))
-    register(Perplexity("mixtral-8x7b-instruct"), aliases=("pp-8x7b-instruct",))
 
 
 class PerplexityOptions(llm.Options):
@@ -90,7 +82,7 @@ class PerplexityOptions(llm.Options):
 
 class Perplexity(llm.Model):
     needs_key = "perplexity"
-    key_env_var = "PERPLEXITY_API_KEY"
+    key_env_var = "LLM_PERPLEXITY_KEY"
     model_id = "perplexity"
     can_stream = True
 


### PR DESCRIPTION
**What's Up**

Yo! Just updated the plugin with the latest from Perplexity

**Changes:**
- Added the 'huge' model to `llm_perplexity.py`.
- Retired the old-timers.
- Updated `README.md` to feature the 'huge' model in the examples.
- Cleaned up `README.md` to remove mentions of the retired models.
- Updated the API key environment variable from `PERPLEXITY_API_KEY` to `LLM_PERPLEXITY_KEY`.

**Testing and Verification:**
- Ensured the model names in `README.md` match those in `llm_perplexity.py`.
- Confirmed all examples in `README.md` are functioning correctly.
- Tested the 'huge' model and it's performing as expected.

Keeping it fresh and up-to-date! 🚀